### PR TITLE
change rspec config

### DIFF
--- a/rspec
+++ b/rspec
@@ -1,1 +1,1 @@
---color --format documentation
+--color


### PR DESCRIPTION
Drop the `documentation` format to use the default progress bar